### PR TITLE
Time micros

### DIFF
--- a/extra/riemann.proto
+++ b/extra/riemann.proto
@@ -1,4 +1,4 @@
-option java_package = "com.aphyr.riemann";
+option java_package = "io.riemann.riemann";
 option java_outer_classname = "Proto";
 
 message State {
@@ -22,6 +22,7 @@ message Event {
   optional float ttl = 8;
   repeated Attribute attributes = 9;
 
+  optional int64 time_micros = 10;
   optional sint64 metric_sint64 = 13;
   optional double metric_d = 14;
   optional float metric_f = 15;

--- a/src/Network/Monitoring/Riemann.hs
+++ b/src/Network/Monitoring/Riemann.hs
@@ -203,8 +203,8 @@ sendTCPEvent _ _  = fail "trying to send TCP event through UDP client"
 sendUDPEvent :: (MonadIO m) => Client -> Event -> ExceptT IOException m Client
 sendUDPEvent (UDP _ _ (Left e)) _ = throwE e
 sendUDPEvent c@(UDP _ _ (Right (s, addy))) e = tryIO $ do
-  now <- fmap round getPOSIXTime
-  let msg = def & events .~ [e & time ?~ now]
+  now <- getPOSIXTime
+  let msg = def & events .~ [e & time ?~ round now & time_micros ?~ round (now * 1e6)]
   void $ sendTo s (runPut $ encodeMessage msg) (addrAddress addy)
   return c
 sendUDPEvent _ _  = fail "trying to send UDP event through TCP client"

--- a/src/Network/Monitoring/Riemann/TCP.hs
+++ b/src/Network/Monitoring/Riemann/TCP.hs
@@ -72,8 +72,8 @@ doConnect hn po = do addrs <- getAddrInfo
 doSendTCPEvent :: IORef TCPState -> Socket -> Event -> IO ()
 doSendTCPEvent r s event = do
   sending <- try $ do
-    now <- fmap round getPOSIXTime
-    let msg = def & events .~ [event & time ?~ now]
+    now <- getPOSIXTime
+    let msg = def & events .~ [event & time ?~ round now & time_micros ?~ round (now * 1e6)]
         bytes = runPut $ encodeMessage msg
         bytesWithLen = runPut (putWord32be (fromIntegral $ BS.length bytes)  >> putByteString bytes)
     void $ send s bytesWithLen

--- a/src/Network/Monitoring/Riemann/Types.hs
+++ b/src/Network/Monitoring/Riemann/Types.hs
@@ -13,7 +13,7 @@ module Network.Monitoring.Riemann.Types (
   HasQuery (..),
   State, Event, Query, Msg,
   ev,
-  once, attributes,
+  once, attributes, time_micros,
   MsgState(..), msgState, states, events,
   Hostname, Port
   ) where
@@ -117,6 +117,7 @@ data Event = Event {
   _eventTtl         :: Optional 8 (Value Float),
 
   _eventAttributes  :: Repeated 9 (Message Attribute),
+  _eventTimeMicros  :: Optional 10 (Value Int64),
   _eventMetricSInt  :: Optional 13 (Value (Signed Int64)),
   _eventMetricD     :: Optional 14 (Value Double),
   _eventMetricF     :: Optional 15 (Value Float)
@@ -250,10 +251,15 @@ attributes = eventAttributes
   where sequen :: Applicative f => (a, f b) -> f (a, b)
         sequen (a, fb) = (a,) <$> fb
 
+-- | optional precision for the event time
+time_micros :: Lens' Event (Maybe Int64)
+time_micros = eventTimeMicros . field
+
 instance Show Event where
   show s = "Event { " ++ intercalate ", " innards ++ " }"
     where innards = catMaybes [
             showM "time" time,
+            showM "time_micros" time_micros,
             showM "state" state,
             showM "service" service,
             showM "host" host,
@@ -282,6 +288,7 @@ instance Default Event where
     _eventDescription = putField Nothing,
     _eventTags        = putField [],
     _eventTtl         = putField Nothing,
+    _eventTimeMicros  = putField Nothing,
     _eventAttributes  = putField [],
     _eventMetricSInt  = putField Nothing,
     _eventMetricD     = putField Nothing,

--- a/src/Network/Monitoring/Riemann/Types.hs
+++ b/src/Network/Monitoring/Riemann/Types.hs
@@ -251,7 +251,9 @@ attributes = eventAttributes
   where sequen :: Applicative f => (a, f b) -> f (a, b)
         sequen (a, fb) = (a,) <$> fb
 
--- | optional precision for the event time
+-- | optional increased precision for the event time
+-- this is the full time value, to uSec precision.
+-- It is NOT the fractional part of the time
 time_micros :: Lens' Event (Maybe Int64)
 time_micros = eventTimeMicros . field
 


### PR DESCRIPTION
This branch adds support for the new 'time_micros' field in the Riemann protocol.
The extra precision time-stamp is very useful when aggregating in e.g. InfluxDB,
where identical timestamps will overwrite existing event data.

cf. Riemann changes
https://github.com/riemann/riemann/blob/f0927d9219e82ad733c0ee85d25fe59ca9279ba1/CHANGES.markdown